### PR TITLE
retry post if 500 and echo warning to stdout

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -398,8 +398,15 @@ http_request() {
     statuscode="$(curl ${ip_version:-} ${CURL_OPTS} -s -w "%{http_code}" -o "${tempcont}" "${2}")"
     curlret="${?}"
   elif [[ "${1}" = "post" ]]; then
-    statuscode="$(curl ${ip_version:-} ${CURL_OPTS} -s -w "%{http_code}" -o "${tempcont}" "${2}" -d "${3}")"
-    curlret="${?}"
+    statuscode=1
+    while [[ ! "${statuscode:0:1}" = "2" ]]; do
+        statuscode="$(curl ${ip_version:-} ${CURL_OPTS} -s -w "%{http_code}" -o "${tempcont}" "${2}" -d "${3}")"
+        curlret="${?}"
+        if [[ ! "${statuscode:0:1}" = "2" ]]; then
+            echo "WARNING: Statuscode is: ${statuscode}, retrying..." >&2
+            sleep 2
+        fi
+    done
   else
     set -e
     _exiterr "Unknown request method: ${1}"


### PR DESCRIPTION
Hello! I forked this repo a year ago and faced many time out errors. I fixed it in my private repo like in pull request. Now I forked it again  and found that bug is still there. So I think my input would help to mitigate 500 errors when issuing certificates for over 300 domains with cloudflare DNS hook. 