### PR TITLE
adding new CLI Command (--cleanupdelete / -gcd)

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1470,9 +1470,11 @@ command_cleanup() {
     load_config
   fi
 
-  # Create global archive directory if not existent
-  if [[ ! -e "${BASEDIR}/archive" ]]; then
-    mkdir "${BASEDIR}/archive"
+  if [[ ! "${PARAM_CLEANUPDELETE:-}" = "yes" ]]; then
+    # Create global archive directory if not existent
+    if [[ ! -e "${BASEDIR}/archive" ]]; then
+      mkdir "${BASEDIR}/archive"
+    fi
   fi
 
   # Allow globbing
@@ -1487,9 +1489,11 @@ command_cleanup() {
     certname="$(basename "${certdir}")"
 
     # Create certificates archive directory if not existent
-    archivedir="${BASEDIR}/archive/${certname}"
-    if [[ ! -e "${archivedir}" ]]; then
-      mkdir "${archivedir}"
+    if [[ ! "${PARAM_CLEANUPDELETE:-}" = "yes" ]]; then
+      archivedir="${BASEDIR}/archive/${certname}"
+      if [[ ! -e "${archivedir}" ]]; then
+        mkdir "${archivedir}"
+      fi
     fi
 
     # Loop over file-types (certificates, keys, signing-requests, ...)
@@ -1508,9 +1512,14 @@ command_cleanup() {
       for file in "${certdir}/${filebase}-"*".${fileext}" "${certdir}/${filebase}-"*".${fileext}-revoked"; do
         # Check if current file is in use, if unused move to archive directory
         filename="$(basename "${file}")"
-        if [[ ! "${filename}" = "${current}" ]]; then
-          echo "Moving unused file to archive directory: ${certname}/${filename}"
-          mv "${certdir}/${filename}" "${archivedir}/${filename}"
+        if [[ ! "${filename}" = "${current}" ]] && [[ -f "${certname}/${filename}" ]]; then
+          if [[ "${PARAM_CLEANUPDELETE:-}" = "yes" ]]; then
+            echo "Deleting unused file: ${certname}/${filename}"
+            rm "${certdir}/${filename}"
+          else
+            echo "Moving unused file to archive directory: ${certname}/${filename}"
+            mv "${certdir}/${filename}" "${archivedir}/${filename}"
+          fi
         fi
       done
     done
@@ -1518,6 +1527,13 @@ command_cleanup() {
 
   exit 0
 }
+
+# Usage: --cleanup-delete (-gcd)
+# Description: Deletes (!) unused certificate files
+command_cleanupdelete() {
+  command_cleanup
+}
+
 
 # Usage: --help (-h)
 # Description: Show help text
@@ -1619,6 +1635,11 @@ main() {
 
       --cleanup|-gc)
         set_command cleanup
+        ;;
+
+      --cleanup-delete|-gcd)
+        set_command cleanupdelete
+        PARAM_CLEANUPDELETE="yes"
         ;;
 
       # PARAM_Usage: --full-chain (-fc)
@@ -1767,6 +1788,7 @@ main() {
     sign_csr) command_sign_csr "${PARAM_CSR}";;
     revoke) command_revoke "${PARAM_REVOKECERT}";;
     cleanup) command_cleanup;;
+    cleanupdelete) command_cleanupdelete;;
     version) command_version;;
     *) command_help; exit 1;;
   esac


### PR DESCRIPTION
Currently it's only possible to move the old certificates into the 'archive' folder. This PR adds the possibility to also delete them, without moving them into the archive folder. The new parameter is '--cleanupdelete'.
Additionally it checks prior archiving/deleting if a file exists - prevents the error-messages of not-existing files.

Let me know if you have any suggestions for improvements!


Thanks and Happy-Merging,
Pfuender