### PR TITLE
support mksh as executing shell

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -110,7 +110,9 @@ verify_config() {
     [[ "${IP_VERSION}" = "4" || "${IP_VERSION}" = "6" ]] || _exiterr "Unknown IP version ${IP_VERSION}... cannot continue."
   fi
   [[ "${API}" == "auto" || "${API}" == "1" || "${API}" == "2" ]] || _exiterr "Unsupported API version defined in config: ${API}"
-  [[ "${OCSP_DAYS}" =~ ^[0-9]+$ ]] || _exiterr "OCSP_DAYS must be a number"
+  case x$OCSP_DAYS in
+  (x*[!0-9]*|x) _exiterr "OCSP_DAYS must be a number" ;;
+  esac
 }
 
 # Setup default config values, search for and load configuration files
@@ -1101,7 +1103,7 @@ command_version() {
   revision="$(cd "${SCRIPTDIR}"; git rev-parse HEAD 2>/dev/null || echo "unknown")"
   echo "GIT-Revision: ${revision}"
   echo ""
-  if [[ "${OSTYPE}" =~ "BSD" ]]; then
+  if [[ "${OSTYPE}" = *BSD* ]]; then
     echo "OS: $(uname -sr)"
   else
     echo "OS: $(cat /etc/issue | grep -v ^$ | head -n1 | _sed 's/\\(r|n|l) .*//g')"
@@ -1110,7 +1112,7 @@ command_version() {
   [[ -n "${BASH_VERSION:-}" ]] && echo " bash: ${BASH_VERSION}"
   [[ -n "${ZSH_VERSION:-}" ]] && echo " zsh: ${ZSH_VERSION}"
   echo " curl: $(curl --version 2>&1 | head -n1 | cut -d" " -f1-2)"
-  if [[ "${OSTYPE}" =~ "BSD" ]]; then
+  if [[ "${OSTYPE}" = *BSD* ]]; then
     echo " awk, sed, mktemp, grep, diff: BSD base system versions"
   else
     echo " awk: $(awk -W version 2>&1 | head -n1)"

--- a/dehydrated
+++ b/dehydrated
@@ -8,8 +8,12 @@
 set -e
 set -u
 set -o pipefail
+if test -n "${KSH_VERSION:-}"; then
+	set -f
+else
 [[ -n "${ZSH_VERSION:-}" ]] && set -o SH_WORD_SPLIT && set +o FUNCTION_ARGZERO && set -o NULL_GLOB && set -o noglob
 [[ -z "${ZSH_VERSION:-}" ]] && shopt -s nullglob && set -f
+fi
 
 umask 077 # paranoid umask, we're creating private keys
 
@@ -1407,7 +1411,7 @@ command_revoke() {
     # follow symlink and use real certificate name (so we move the real file and not the symlink at the end)
     local link_target
     link_target="$(readlink -n "${cert}")"
-    if [[ "${link_target}" =~ ^/ ]]; then
+    if [[ "${link_target}" = /* ]]; then
       cert="${link_target}"
     else
       cert="$(dirname "${cert}")/${link_target}"
@@ -1493,14 +1497,14 @@ command_help() {
   printf "Default command: help\n\n"
   echo "Commands:"
   grep -e '^[[:space:]]*# Usage:' -e '^[[:space:]]*# Description:' -e '^command_.*()[[:space:]]*{' "${0}" | while read -r usage; read -r description; read -r command; do
-    if [[ ! "${usage}" =~ Usage ]] || [[ ! "${description}" =~ Description ]] || [[ ! "${command}" =~ ^command_ ]]; then
+    if [[ ! "${usage}" = *Usage* ]] || [[ ! "${description}" = *Description* ]] || [[ ! "${command}" = command_* ]]; then
       _exiterr "Error generating help text."
     fi
     printf " %-32s %s\n" "${usage##"# Usage: "}" "${description##"# Description: "}"
   done
   printf -- "\nParameters:\n"
   grep -E -e '^[[:space:]]*# PARAM_Usage:' -e '^[[:space:]]*# PARAM_Description:' "${0}" | while read -r usage; read -r description; do
-    if [[ ! "${usage}" =~ Usage ]] || [[ ! "${description}" =~ Description ]]; then
+    if [[ ! "${usage}" = *Usage* ]] || [[ ! "${description}" = *Description* ]]; then
       _exiterr "Error generating help text."
     fi
     printf " %-32s %s\n" "${usage##"# PARAM_Usage: "}" "${description##"# PARAM_Description: "}"

--- a/dehydrated
+++ b/dehydrated
@@ -38,7 +38,7 @@ ORIGARGS="$@"
 # Create (identifiable) temporary files
 _mktemp() {
   # shellcheck disable=SC2068
-  mktemp ${@:-} "${TMPDIR:-/tmp}/dehydrated-XXXXXX"
+  mktemp "$@" "${TMPDIR:-/tmp}/dehydrated-XXXXXX"
 }
 
 # Check for script dependencies
@@ -1740,5 +1740,5 @@ OSTYPE="$(uname)"
 
 if [[ ! "${DEHYDRATED_NOOP:-}" = "NOOP" ]]; then
   # Run script
-  main "${@:-}"
+  main "$@"
 fi


### PR DESCRIPTION
Basic support for running under [The MirBSD Korn Shell](http://www.mirbsd.org/mksh.htm), the Unix shell with probably the most users (as it’s the Android default shell, among others):

- set -f exists, nullglob doesn’t, but considering we use noglob, it shouldn’t be needed
- use shell extglobs instead of regular expressions