### PR TITLE
Only check existing certs when necessary

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1304,7 +1304,7 @@ command_sign_domains() {
     fi
 
     # Check domain names of existing certificate
-    if [[ -e "${cert}" ]]; then
+    if [[ -e "${cert}" && "${force_renew}" = "no" ]]; then
       printf " + Checking domain name(s) of existing cert..."
 
       certnames="$("${OPENSSL}" x509 -in "${cert}" -text -noout | grep DNS: | _sed 's/DNS://g' | tr -d ' ' | tr ',' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//')"


### PR DESCRIPTION
Fixes https://github.com/lukas2511/dehydrated/issues/230

The expiry date check could be skipped too.

Some extra info:
I tried running dehydrated on an entware installation + lighttpd webserver based on [this](https://redmine.lighttpd.net/projects/lighttpd/wiki/HowToSimpleSSL#Lets-Encrypt-bootstrap-using-TLS-ALPN-01-verification-challenge-and-dehydrated-with-lighttpd-1453).
Unfortunately, the openssl package in entware doesn't support the -extensions req_ext flag, hence there's no DNS section in generated keys.
I tried running the script without any certificates, but lighttpd doesn't want to start when the certs in its config do not exist. Dehydrated doesn't want to generate certs when it fails to parse the DNS section in existing certs. A bit of a chicken/egg situation.

Hence, when forcing to generate certs anyway, do not parse the existing certs.. the main goal of that section is to enable the force flag anyway.


