### PR TITLE
cleanup: also do cleanup if symlink is broken

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1515,11 +1515,13 @@ command_cleanup() {
 
     # Loop over file-types (certificates, keys, signing-requests, ...)
     for filetype in cert.csr cert.pem chain.pem fullchain.pem privkey.pem ocsp.der; do
-      # Skip if symlink is broken
-      [[ -r "${certdir}/${filetype}" ]] || continue
-
-      # Look up current file in use
-      current="$(basename "$(readlink "${certdir}/${filetype}")")"
+      # Delete all if symlink is broken
+      if [[ -r "${certdir}/${filetype}" ]]; then
+        # Look up current file in use
+        current="$(basename "$(readlink "${certdir}/${filetype}")")"
+      else
+        current=""
+      fi
 
       # Split filetype into name and extension
       filebase="$(echo "${filetype}" | cut -d. -f1)"


### PR DESCRIPTION
The cleanup command skips filetypes for which the symlink is broken or
doesn't exist. However, if dehydrated fails, we may end up in exactly
the situation that the symlink doesn't exist (yet). If dehydrated fails
repeatedly, we may end up with a lot of old cert.csr, cert.pem and
privkey.pem files, so we really want to be able to clean them up.

Remove all files if the symlink is broken/missing, instead of skipping
those files.

Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>