### PR TITLE
Add missing " in hook example

### DIFF
--- a/docs/examples/hook.sh
+++ b/docs/examples/hook.sh
@@ -60,7 +60,7 @@ sync_cert() {
     #   The path of the file containing the certificate signing request.
 
     # Simple example: sync the files before symlinking them
-    # sync "${KEYFILE}" "${CERTFILE} "${FULLCHAINFILE}" "${CHAINFILE}" "${REQUESTFILE}"
+    # sync "${KEYFILE}" "${CERTFILE}" "${FULLCHAINFILE}" "${CHAINFILE}" "${REQUESTFILE}"
 }
 
 deploy_cert() {


### PR DESCRIPTION
In the example sync_cert hook one `"` is missing. So it would be a broken hook script if you just uncomment that line.