### PR TITLE
docs: use `service` instead of `systemctl` in the examples

### DIFF
--- a/docs/examples/hook.sh
+++ b/docs/examples/hook.sh
@@ -87,7 +87,7 @@ deploy_cert() {
 
     # Simple example: Copy file to nginx config
     # cp "${KEYFILE}" "${FULLCHAINFILE}" /etc/nginx/ssl/; chown -R nginx: /etc/nginx/ssl
-    # systemctl reload nginx
+    # service nginx reload
 }
 
 deploy_ocsp() {
@@ -108,7 +108,7 @@ deploy_ocsp() {
 
     # Simple example: Copy file to nginx config
     # cp "${OCSPFILE}" /etc/nginx/ssl/; chown -R nginx: /etc/nginx/ssl
-    # systemctl reload nginx
+    # service nginx reload
 }
 
 


### PR DESCRIPTION
`systemctl` is specific to systemd, whereas `service` is a init system
agnostic command, that can run in all OSes I know about.

I've been asked to do it [in this Debian bug](https://bugs.debian.org/945908)