### PR TITLE
Fix curl check regression and simplify

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -51,7 +51,7 @@ check_dependencies() {
   local _tmp="$(curl -V 2>/dev/null)"
   retcode="$?"
   set -e
-  CURL_VERSION="$(echo "${_tmp}" | head -n1 | awk '{print $2}')"
+  read _ CURL_VERSION _ <<<"${_tmp}"
   if [[ ! "${retcode}" = "0" ]] && [[ ! "${retcode}" = "2" ]]; then
     _exiterr "This script requires curl."
   fi

--- a/dehydrated
+++ b/dehydrated
@@ -48,9 +48,10 @@ check_dependencies() {
 
   # curl returns with an error code in some ancient versions so we have to catch that
   set +e
-  CURL_VERSION="$(curl -V 2>&1 | head -n1 | awk '{print $2}')"
+  local _tmp="$(curl -V 2>/dev/null)"
   retcode="$?"
   set -e
+  CURL_VERSION="$(echo "${_tmp}" | head -n1 | awk '{print $2}')"
   if [[ ! "${retcode}" = "0" ]] && [[ ! "${retcode}" = "2" ]]; then
     _exiterr "This script requires curl."
   fi

--- a/dehydrated
+++ b/dehydrated
@@ -1106,7 +1106,7 @@ command_version() {
   echo "Used software:"
   [[ -n "${BASH_VERSION:-}" ]] && echo " bash: ${BASH_VERSION}"
   [[ -n "${ZSH_VERSION:-}" ]] && echo " zsh: ${ZSH_VERSION}"
-  echo " curl: $(curl --version 2>&1 | head -n1 | cut -d" " -f1-2)"
+  echo " curl: ${CURL_VERSION}"
   if [[ "${OSTYPE}" =~ "BSD" ]]; then
     echo " awk, sed, mktemp, grep, diff: BSD base system versions"
   else


### PR DESCRIPTION
This fixes #717 by capturing the output into a string for later version extraction.

Additionally, it replaces the subshell calls to `head` and `awk` with basic
`bash` `read` which is 95+ times faster (in my tests, based on 100000
iterations), simpler and safer (no forking that could fail etc).

**NOTE:** You'll notice I'm not redirecting `stderr` anymore. Even the oldest
version of `curl` I could find (4.8 from 2000) still outputs to `stdout` so I'm
not sure why this is being captured.

Lastly, it also reuses the curl version information previously obtained for the
`command_version()` function.