### PR TITLE
Fix account URL

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -408,17 +408,17 @@ init_system() {
       ACCOUNT_URL="${CA_REG}/${ACCOUNT_ID}"
     else
       if [[ -e "${ACCOUNT_ID_JSON}" ]]; then
-        ACCOUNT_ID="$(cat "${ACCOUNT_ID_JSON}" | get_json_string_value id)"
-      else
-        echo "+ Fetching account ID..."
+        ACCOUNT_URL="$(cat "${ACCOUNT_ID_JSON}" | get_json_string_value url)"
+      fi
+      # if account URL is not storred, fetch it from the CA
+      if [[ -z "${ACCOUNT_URL:-}" ]]; then
+        echo "+ Fetching account URL..."
         ACCOUNT_URL="$(signed_request "${CA_NEW_ACCOUNT}" '{"onlyReturnExisting": true}' 4>&1 | grep -i ^Location: | awk '{print $2}' | tr -d '\r\n')"
-        ACCOUNT_ID="${ACCOUNT_URL##*/}"
-        if [[ -z "${ACCOUNT_ID}" ]]; then
+        if [[ -z "${ACCOUNT_URL}" ]]; then
           _exiterr "Unknown error on fetching account information"
         fi
-        echo '{"id": "'"${ACCOUNT_ID}"'"}' > "${ACCOUNT_ID_JSON}"
+        echo '{"url":"'"${ACCOUNT_URL}"'"}' > "${ACCOUNT_ID_JSON}" # store the URL for next time
       fi
-      ACCOUNT_URL="${CA_ACCOUNT}/${ACCOUNT_ID}"
     fi
   else
     echo "Fetching missing account information from CA..."
@@ -428,7 +428,6 @@ init_system() {
       ACCOUNT_URL="$(signed_request "${CA_NEW_ACCOUNT}" '{"onlyReturnExisting": true}' 4>&1 | grep -i ^Location: | awk '{print $2}' | tr -d '\r\n')"
       ACCOUNT_INFO="$(signed_request "${ACCOUNT_URL}" '{}')"
     fi
-    ACCOUNT_ID="${ACCOUNT_URL##*/}"
     echo "${ACCOUNT_INFO}" > "${ACCOUNT_KEY_JSON}"
   fi
 }
@@ -1155,12 +1154,12 @@ command_account() {
 
   NEW_ACCOUNT_KEY_JSON="$(_mktemp)"
 
-  # Check if we have the registration id
-  if [[ -z "${ACCOUNT_ID}" ]]; then
-    _exiterr "Error retrieving registration id."
+  # Check if we have the registration url
+  if [[ -z "${ACCOUNT_URL}" ]]; then
+    _exiterr "Error retrieving registration url."
   fi
 
-  echo "+ Updating registration id: ${ACCOUNT_ID} contact information..."
+  echo "+ Updating registration url: ${ACCOUNT_URL} contact information..."
   if [[ ${API} -eq 1 ]]; then
     # If an email for the contact has been provided then adding it to the registered account
     if [[ -n "${CONTACT_EMAIL}" ]]; then


### PR DESCRIPTION
Fixes #671. Note that I did not change the ACMEv1 code at all, not sure what that version of the protocol is supposed to do.

We store the account URL on account creation in the `account_id.json` file.

When reading the file, if the attribute is missing, we fall back to previous behaviour, with a warning message.

---

Per https://tools.ietf.org/html/rfc8555#section-7.3
> The server returns this account object in a 201 (Created) response, with the account URL in a Location header field.  The account URL is used as the "kid" value in the JWS authenticating subsequent requests by this account (see Section 6.2).  The account URL is also used for requests for management actions on this account, as described below.