### PR TITLE
Don't assume order status to be valid, retry if needed

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -699,7 +699,8 @@ sign_csr() {
     challenge_identifiers="[${challenge_identifiers%, }]"
 
     echo " + Requesting new certificate order from CA..."
-    result="$(signed_request "${CA_NEW_ORDER}" '{"identifiers": '"${challenge_identifiers}"'}')"
+    order_location="$(signed_request "${CA_NEW_ORDER}" '{"identifiers": '"${challenge_identifiers}"'}' 4>&1 | grep -i ^Location: | awk '{print $2}' | tr -d '\r\n')"
+    result="$(signed_request "${order_location}" "" | clean_json)"
 
     order_authorizations="$(echo ${result} | get_json_array_value authorizations)"
     finalize="$(echo "${result}" | get_json_string_value finalize)"
@@ -867,8 +868,27 @@ sign_csr() {
     crt64="$(signed_request "${CA_NEW_CERT}" '{"resource": "new-cert", "csr": "'"${csr64}"'"}' | "${OPENSSL}" base64 -e)"
     crt="$( printf -- '-----BEGIN CERTIFICATE-----\n%s\n-----END CERTIFICATE-----\n' "${crt64}" )"
   else
-    result="$(signed_request "${finalize}" '{"csr": "'"${csr64}"'"}' | clean_json | get_json_string_value certificate)"
-    crt="$(signed_request "${result}" "")"
+    result="$(signed_request "${finalize}" '{"csr": "'"${csr64}"'"}' | clean_json)"
+    while :
+    do
+      status="$(echo "${result}" | get_json_string_value status)"
+      echo "   > Order is ${status}..."
+      case "${status}"
+      in
+        "processing" | "pending")
+          sleep 2;
+          ;;
+        "valid")
+          break;
+          ;;
+        *)
+          _exiterr "Order in status ${status}"
+          ;;
+      esac
+      result="$(signed_request "${order_location}" "" | clean_json)"
+    done
+    certificate="$(echo "${result}" | get_json_string_value certificate)"
+    crt="$(signed_request "${certificate}" "")"
   fi
 
   # Try to load the certificate to detect corruption


### PR DESCRIPTION
Fixes #673. Replaces & closes #639.

---

The issue is well described by @alexzorin in #673: the status of the orders can be different from `valid`, in which case we should retry fetching the certificate.

Per https://tools.ietf.org/html/rfc8555#section-7.1.3

> status (required, string):  The status of this order.  Possible values are "pending", "ready", "processing", "valid", and "invalid".  See Section 7.1.6.

---

To get the certificate, we need to call the order URL. It is not 100% clear in the RFC where to find that URL, but the consensus seems to be the `Location` header when posting a new order:
 - [RFC shows that in the "typical sequence of requests"](https://tools.ietf.org/html/rfc8555#section-7.1)
 - [This thread on Let's Encrypt forum](https://community.letsencrypt.org/t/is-the-location-header-of-an-new-order-the-orders-url-in-boulder-letsencrypt/112632)
 - Other ACME clients doing that as well (e.g. [certbot](https://github.com/certbot/certbot/blob/809cb516c918575bc1688141dfe9b4da001d6570/acme/acme/client.py#L674), [acme-tiny](https://github.com/diafygi/acme-tiny/blob/0a9afb2b72bafad29d172f9d3d704ef979530fe3/acme_tiny.py#L159))

So this is what I am doing here.

Unfortunately, it seems to be difficult to get both the response and the response header of the new order request, due to bash / the way the code is organised (we would need to store in two separate variables `stdout` and `fd 4`, and [that seems rather difficult](https://stackoverflow.com/q/11027679)).

So I am doing two requests instead of one when creating the order:
 1. Create the order and get the order URL from the `Location` header;
 2. Retrieve the order to get various data from the body.

Feel free to offer better alternatives!

---

Between retries, I am waiting 2 seconds. For comparison:
 - [certbot](https://github.com/certbot/certbot/blob/809cb516c918575bc1688141dfe9b4da001d6570/acme/acme/client.py#L751) is waiting 1 second;
 - [acme-tiny](https://github.com/diafygi/acme-tiny/blob/0a9afb2b72bafad29d172f9d3d704ef979530fe3/acme_tiny.py#L69) is waiting 2 seconds.

---

Finally, I did not change the way things are handled in ACMEv1, I'm not sure if it is worth looking into.