### PR TITLE
Fix tls-alpn-01 configuration example

### DIFF
--- a/docs/tls-alpn.md
+++ b/docs/tls-alpn.md
@@ -15,18 +15,16 @@ Your config should look something like this:
 
 ```nginx
 stream {
-  server {
-    map $ssl_preread_alpn_protocols $tls_port {
-      ~\bacme-tls/1\b 10443;
-      default 443;
-    }
+  map $ssl_preread_alpn_protocols $tls_port {
+    ~\bacme-tls/1\b 10443;
+    default 443;
+  }
 
-    server {
-      listen 443;
-      listen [::]:443;
-      proxy_pass 10.13.37.42:$tls_port;
-      ssl_preread on;
-    }
+  server {
+    listen 443;
+    listen [::]:443;
+    proxy_pass 10.13.37.42:$tls_port;
+    ssl_preread on;
   }
 }
 ```


### PR DESCRIPTION
Using nginx 1.14, I get an error about `map` not being valid inside a `server` block. According to [the docs](https://nginx.org/en/docs/stream/ngx_stream_map_module.html#map) it's only valid in a `stream` block. I made the change on my server and it fixed it for me, this updates the example.