### PR TITLE
removed tmp file in 'generate_alpn_certificate' function

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -976,6 +976,7 @@ generate_alpn_certificate() {
   SUBJ="/CN=${altname}/"
   [[ "${OSTYPE:0:5}" = "MINGW" ]] && SUBJ="/${SUBJ}"
   _openssl req -x509 -new -sha256 -nodes -newkey rsa:2048 -keyout "${alpncertdir}/${altname}.key.pem" -out "${alpncertdir}/${altname}.crt.pem" -subj "${SUBJ}" -extensions SAN -config "${tmp_openssl_cnf}"
+  rm -f "${tmp_openssl_cnf}"
 }
 
 # Create certificate for domain(s)


### PR DESCRIPTION
Made sure that the temp file will be removed at the end of the function.