### PR TITLE
fix OS name detection

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1369,6 +1369,10 @@ command_version() {
   echo ""
   if [[ "${OSTYPE}" =~ "BSD" ]]; then
     echo "OS: $(uname -sr)"
+  elif [[ -e /etc/os-release ]]; then
+    ( . /etc/os-release && echo "OS: $PRETTY_NAME" )
+  elif [[ -e /usr/lib/os-release ]]; then
+    ( . /usr/lib/os-release && echo "OS: $PRETTY_NAME" )
   else
     echo "OS: $(cat /etc/issue | grep -v ^$ | head -n1 | _sed 's/\\(r|n|l) .*//g')"
   fi


### PR DESCRIPTION
before applying heuristics, use `PRETTY_NAME` from os-release(3),
which reliably exists on all common linux distributions.

keep the /etc/issue parsing as fallback.