### PR TITLE
Support for LibreSSL version of `openssl` on macOS

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1060,7 +1060,7 @@ sign_csr() {
         keyauth_hook="$(printf '%s' "${keyauth}" | "${OPENSSL}" dgst -sha256 -binary | urlbase64)"
         ;;
       "tls-alpn-01")
-        keyauth_hook="$(printf '%s' "${keyauth}" | "${OPENSSL}" dgst -sha256 -c -hex | awk '{print $2}')"
+        keyauth_hook="$(printf '%s' "${keyauth}" | "${OPENSSL}" dgst -sha256 -c -hex | awk '{print $NF}')"
         generate_alpn_certificate "${identifier}" "${keyauth_hook}"
         ;;
     esac


### PR DESCRIPTION
When using the native `openssl` on macOS 10.14.6 Mojave, the output of `openssl dgst -sha256 -c -hex` is slightly different (`(stdin)= ` vs not). This PR allows for both styles of output.

### More Information
```
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.14.6
BuildVersion:	18G6032

$ which openssl
/usr/bin/openssl

$ $(which openssl) version
LibreSSL 2.6.5

$ /usr/local/openssl-1.1.1g/bin/openssl version
OpenSSL 1.1.1g  21 Apr 2020
```

#### Using macOS version of `openssl`
```
$ printf %s voMCgod0Y9dLXdu4UHOvstn1Ah3QFcl_k6odYRoOJRA.NTdUdXp2fAk-ZSiRqXVaLG2RN0Z81qvvLAKlZWn_0Hc | /usr/bin/openssl dgst -sha256 -c -hex
5b:2a:0d:26:cd:30:b6:20:47:d2:0d:e9:8e:d1:93:db:01:a2:9c:df:03:20:ad:07:b6:64:64:21:37:47:5f:cf

# Original AWK
$ printf %s voMCgod0Y9dLXdu4UHOvstn1Ah3QFcl_k6odYRoOJRA.NTdUdXp2fAk-ZSiRqXVaLG2RN0Z81qvvLAKlZWn_0Hc | /usr/bin/openssl dgst -sha256 -c -hex | awk '{print $2}'
<empty return>

# PR AWK
$ printf %s voMCgod0Y9dLXdu4UHOvstn1Ah3QFcl_k6odYRoOJRA.NTdUdXp2fAk-ZSiRqXVaLG2RN0Z81qvvLAKlZWn_0Hc | /usr/bin/openssl dgst -sha256 -c -hex | awk '{print $NF}'
5b:2a:0d:26:cd:30:b6:20:47:d2:0d:e9:8e:d1:93:db:01:a2:9c:df:03:20:ad:07:b6:64:64:21:37:47:5f:cf
```

#### Using pure `openssl`
```
$ printf %s voMCgod0Y9dLXdu4UHOvstn1Ah3QFcl_k6odYRoOJRA.NTdUdXp2fAk-ZSiRqXVaLG2RN0Z81qvvLAKlZWn_0Hc | /usr/local/openssl-1.1.1g/bin/openssl dgst -sha256 -c -hex
(stdin)= 5b:2a:0d:26:cd:30:b6:20:47:d2:0d:e9:8e:d1:93:db:01:a2:9c:df:03:20:ad:07:b6:64:64:21:37:47:5f:cf

# Original AWK
$ printf %s voMCgod0Y9dLXdu4UHOvstn1Ah3QFcl_k6odYRoOJRA.NTdUdXp2fAk-ZSiRqXVaLG2RN0Z81qvvLAKlZWn_0Hc | /usr/local/openssl-1.1.1g/bin/openssl dgst -sha256 -c -hex | awk '{print $2}'
5b:2a:0d:26:cd:30:b6:20:47:d2:0d:e9:8e:d1:93:db:01:a2:9c:df:03:20:ad:07:b6:64:64:21:37:47:5f:cf

# PR AWK
$ printf %s voMCgod0Y9dLXdu4UHOvstn1Ah3QFcl_k6odYRoOJRA.NTdUdXp2fAk-ZSiRqXVaLG2RN0Z81qvvLAKlZWn_0Hc | /usr/local/openssl-1.1.1g/bin/openssl dgst -sha256 -c -hex | awk '{print $NF}'
5b:2a:0d:26:cd:30:b6:20:47:d2:0d:e9:8e:d1:93:db:01:a2:9c:df:03:20:ad:07:b6:64:64:21:37:47:5f:cf
```