### PR TITLE
Support reading domains from drop-in snippets in `domains.txt.d`

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1532,6 +1532,20 @@ command_account() {
   exit 0
 }
 
+# Parse contents of domains.txt and domains.txt.d
+parse_domains_txt() {
+  # Allow globbing temporarily
+  [[ -n "${ZSH_VERSION:-}" ]] && set +o noglob || set +f
+  local inputs=("${DOMAINS_TXT}" "${DOMAINS_TXT}.d"/*.txt)
+  [[ -n "${ZSH_VERSION:-}" ]] && set -o noglob || set -f
+
+  cat "${inputs[@]}" |
+    tr -d '\r' |
+    awk '{print tolower($0)}' |
+    _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' |
+    (grep -vE '^(#|$)' || true)
+}
+
 # Usage: --cron (-c)
 # Description: Sign/renew non-existent/changed/expiring certificates.
 command_sign_domains() {
@@ -1564,7 +1578,7 @@ command_sign_domains() {
   # Generate certificates for all domains found in domains.txt. Check if existing certificate are about to expire
   ORIGIFS="${IFS}"
   IFS=$'\n'
-  for line in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
+  for line in $(parse_domains_txt); do
     reset_configvars
     IFS="${ORIGIFS}"
     alias="$(grep -Eo '>[^ ]+' <<< "${line}" || true)"

--- a/docs/domains_txt.md
+++ b/docs/domains_txt.md
@@ -70,3 +70,10 @@ This creates two certificates one for `service.example.com` with an
 **Note:** The first certificate is valid for both `service.example.com` and for
 `*.service.example.com` which can be a useful way to create wildcard
 certificates.
+
+### Drop-in directory
+
+If a directory named `domains.txt.d` exists in the same location as
+`domains.txt`, the contents of `*.txt` files in that directory are appended to
+the list of domains, in alphabetical order of the filenames. This is useful for
+automation, as it doesn't require editing an existing file to add new domains.


### PR DESCRIPTION
This adds support for a directory `domains.txt.d` in the same location as `domains.txt`, which can contain further files in the same format as `domains.txt` that are automatically read and appended to the list of domains.

This follows the common pattern of config drop-in directories that is used by e.g. Nginx, Apache, systemd etc. It allows adding new domains by simply dropping a new file in the directory instead of editing an existing file, which is useful for automation and scripting.