### PR TITLE
Update staging.md to use ACMEv2 server

### DIFF
--- a/docs/staging.md
+++ b/docs/staging.md
@@ -8,10 +8,5 @@ you will quickly hit these limits and find yourself locked out.
 To avoid this, please set the CA property to the Let’s Encrypt staging server URL in your config file:
 
 ```bash
-CA="https://acme-staging.api.letsencrypt.org/directory"
+CA="https://acme-staging-v02.api.letsencrypt.org/directory"
 ```
-
-# ACMEv2 staging
-
-You can use `CA="https://acme-staging-v02.api.letsencrypt.org/directory"` to test dehydrated with
-the ACMEv2 staging endpoint.


### PR DESCRIPTION
letsencrypt is phasing out the v1 server:

```
# dehydrated -c
# INFO: Using main config file /etc/dehydrated/config
  + ERROR: An error occurred while sending get-request to https://acme-staging.api.letsencrypt.org/directory (Status 403)

Details:
HTTP/2 403 
server: nginx
date: Thu, 01 Apr 2021 20:48:17 GMT
content-type: application/problem+json
content-length: 189
etag: "600b3710-bd"

{
  "type": "urn:acme:error:serverInternal",
  "detail": "ACMEv1 Brownout in Progress. ACMEv1 will fully turn off on June 1, 2021. Check https://letsencrypt.status.io/ for more details."
}


```