### PR TITLE
ensure newline before new section in openssl.cnf

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1291,7 +1291,7 @@ generate_alpn_certificate() {
   echo " + Generating ALPN certificate and key for ${1}..."
   tmp_openssl_cnf="$(_mktemp)"
   cat "${OPENSSL_CNF}" > "${tmp_openssl_cnf}"
-  printf "[SAN]\nsubjectAltName=DNS:%s\n" "${altname}" >> "${tmp_openssl_cnf}"
+  printf "\n[SAN]\nsubjectAltName=DNS:%s\n" "${altname}" >> "${tmp_openssl_cnf}"
   printf "1.3.6.1.5.5.7.1.31=critical,DER:04:20:${acmevalidation}\n" >> "${tmp_openssl_cnf}"
   SUBJ="/CN=${altname}/"
   [[ "${OSTYPE:0:5}" = "MINGW" ]] && SUBJ="/${SUBJ}"
@@ -1365,7 +1365,7 @@ sign_domain() {
     local tmp_openssl_cnf
     tmp_openssl_cnf="$(_mktemp)"
     cat "${OPENSSL_CNF}" > "${tmp_openssl_cnf}"
-    printf "[SAN]\nsubjectAltName=%s" "${SAN}" >> "${tmp_openssl_cnf}"
+    printf "\n[SAN]\nsubjectAltName=%s" "${SAN}" >> "${tmp_openssl_cnf}"
     if [ "${OCSP_MUST_STAPLE}" = "yes" ]; then
       printf "\n1.3.6.1.5.5.7.1.24=DER:30:03:02:01:05" >> "${tmp_openssl_cnf}"
     fi


### PR DESCRIPTION
openssl.cnf may not end with a newline. The section [SAN] will then not be found as it is added to the last line of openssl.cnf.