### PR TITLE
Better handling around grep/awk

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -88,7 +88,7 @@ jsonsh() {
   awk_egrep () {
     local pattern_string=$1
 
-    gawk '{
+    awk '{
       while ($0) {
         start=match($0, pattern);
         token=substr($0, start, RLENGTH);
@@ -110,7 +110,7 @@ jsonsh() {
       GREP='egrep -ao'
     fi
 
-    if echo "test string" | egrep -o "test" >/dev/null 2>&1
+    if echo "test string" | egrep -ao "test" >/dev/null 2>&1
     then
       ESCAPE='(\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})'
       CHAR='[^[:cntrl:]"\\]'


### PR DESCRIPTION
This fixes #839.

* Test `egrep -ao` instead of just `-o` to avoid selecting `egrep` when `-a` is not supported  (i.e., gnu-grep egrep is not available)
* Use `awk` instead of `gawk`. `gawk` doesn't support the escape sequence passed, so it wouldn't anyway. But Non-GNU systems will usually have a different flavor of awk where the escape sequence *does* work.

This has been tested on:

* CentOS 7
* CentOS 8
* Debian 10
* FreeBSD
* illumos (SmartOS)
* Ubuntu 20.04

I can also test on others if that's helpful.