### PR TITLE
doc: replace unknown ecdsa algorithm reference

### DIFF
--- a/docs/domains_txt.md
+++ b/docs/domains_txt.md
@@ -55,7 +55,7 @@ KEY_ALGO="rsa"
 or respectively
 
 ```
-KEY_ALGO="ecdsa"
+KEY_ALGO="secp384r1"
 ```
 
 ### Wildcards


### PR DESCRIPTION
In the 'domains.txt' doc, 'ecdsa' is used as example value for the
'KEY_ALGO' variable, but this is not a valid algorithm.

- Replaced 'ecdsa' with 'secp384r1' in the 'domains.txt' doc.

Closes #863