### PR TITLE
Replace all escaped slashes in json strings

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -217,7 +217,7 @@ jsonsh() {
       '[') parse_array  "$jpath" ;;
       # At this point, the only valid single-character tokens are digits.
       ''|[!0-9]) throw "EXPECTED value GOT ${token:-EOF}" ;;
-      *) value="${token/\\\///}"
+      *) value="${token//\\\///}"
          # replace solidus ("\/") in json strings with normalized value: "/"
          ;;
     esac


### PR DESCRIPTION
`${var/pattern/string}` will only replace the first occurence. We should
use `${var//pattern/string}` to replace all escaped slashes.