### PR TITLE
Add missing checks and fix hexdump output

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -249,7 +249,7 @@ _mktemp() {
 # Check for script dependencies
 check_dependencies() {
   # look for required binaries
-  for binary in grep mktemp diff sed awk curl cut; do
+  for binary in grep mktemp diff sed awk curl cut head tail hexdump; do
     bin_path="$(command -v "${binary}" 2>/dev/null)" || _exiterr "This script requires ${binary}."
     [[ -x "${bin_path}" ]] || _exiterr "${binary} found in PATH but it's not executable"
   done
@@ -828,7 +828,7 @@ hex2bin() {
 
 # Convert binary data to hex string
 bin2hex() {
-  hexdump -e '16/1 "%02x"'
+  hexdump -v -e '/1 "%02x"'
 }
 
 # OpenSSL writes to stderr/stdout even when there are no errors. So just


### PR DESCRIPTION
`hexdump` in the format used, output will sometimes be condensed for repeat characters and spaces may also be present at the end of the output. eg.

```bash
echo '111111111111111111111111111111112345'|hexdump -e '16/1 "%02x"'|sed 's#^#|#;s#$#|#'
```

OUTPUT:
```
|31313131313131313131313131313131*|
|323334350a                      |
```

Recommended instead:

```bash
echo '111111111111111111111111111111112345'|hexdump -v -e '/1 "%02x"'|sed 's#^#|#;s#$#|#'
```

OUTPUT:
```
|3131313131313131313131313131313131313131313131313131313131313131323334350a|
```

This also incorporates some missing checks such as for `head`, `tail` ( as per #877 ) and `hexdump`.