### PR TITLE
Replace "egrep" with "grep -E"

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -126,7 +126,7 @@ jsonsh() {
     fi
 
     # shellcheck disable=SC2196
-    if echo "test string" | egrep -ao "test" >/dev/null 2>&1
+    if echo "test string" | grep -Eao "test" >/dev/null 2>&1
     then
       ESCAPE='(\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})'
       CHAR='[^[:cntrl:]"\\]'


### PR DESCRIPTION
Both egrep and fgrep have been marked obsolete and will issue a warning to stderr now if used.

> egrep, fgrep: now obsolete
> https://git.savannah.gnu.org/cgit/grep.git/commit/?id=a95156247098

But "grep -E" does the same and is required by POSIX:

> grep - search a file for a pattern
> https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html

Signed-off-by: Christian Kujau <lists@nerdbynature.de>