### PR TITLE
egrep -> grep -E

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -126,7 +126,7 @@ jsonsh() {
     fi
 
     # shellcheck disable=SC2196
-    if echo "test string" | egrep -ao "test" >/dev/null 2>&1
+    if echo "test string" | grep -Eao "test" >/dev/null 2>&1
     then
       ESCAPE='(\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})'
       CHAR='[^[:cntrl:]"\\]'


### PR DESCRIPTION
Prevent the warnings described in issue #889. I only found one occurrance of `egrep` being used.

(closes #889 )