### PR TITLE
Retry deploy_cert on later dehydrated runs.

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1549,9 +1549,7 @@ sign_domain() {
   ln -sf "fullchain-${timestamp}.pem" "${certdir}/fullchain.pem"
   ln -sf "cert-${timestamp}.csr" "${certdir}/cert.csr"
   ln -sf "cert-${timestamp}.pem" "${certdir}/cert.pem"
-
-  # Wait for hook script to clean the challenge and to deploy cert if used
-  [[ -n "${HOOK}" ]] && ("${HOOK}" "deploy_cert" "${domain}" "${certdir}/privkey.pem" "${certdir}/cert.pem" "${certdir}/fullchain.pem" "${certdir}/chain.pem" "${timestamp}" || _exiterr 'deploy_cert hook returned with non-zero exit code')
+  echo "${timestamp}" > "${certdir}/todeploy.txt"
 
   unset challenge_token
   echo " + Done!"
@@ -1861,6 +1859,12 @@ command_sign_domains() {
       else
         sign_domain "${certdir}" "${timestamp}" "${domain}" ${morenames}
       fi
+    fi
+
+    if [[ -f "${certdir}/todeploy.txt" ]]; then
+      # Deploy the cert. If this fails the operation will be retried next run.
+      [[ -n "${HOOK}" ]] && ("${HOOK}" "deploy_cert" "${domain}" "${certdir}/privkey.pem" "${certdir}/cert.pem" "${certdir}/fullchain.pem" "${certdir}/chain.pem" "$(cat ${certdir}/todeploy.txt)" || _exiterr 'deploy_cert hook returned with non-zero exit code')
+      rm -f "${certdir}/todeploy.txt"
     fi
 
     if [[ "${OCSP_FETCH}" = "yes" ]]; then


### PR DESCRIPTION
Move the deploy_cert call hook out of the direct cert generation. This allows a retry of the deploy_cert step if it fails (hook returning non-zero exit code).

Adds a new "todeploy.txt" in the cert dir until cert deployment succeeds.