### PR TITLE
Fix an occasional broken pipe error message.

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -118,7 +118,7 @@ jsonsh() {
     local ESCAPE
     local CHAR
 
-    if echo "test string" | grep -Eao --color=never "test" >/dev/null 2>&1
+    if echo "test string" 2>/dev/null| grep -Eao --color=never "test" >/dev/null 2>&1
     then
       GREP='grep -Eao --color=never'
     else


### PR DESCRIPTION
On systems not supporting --color=never the check can occasionally cause a broken pipe error. This avoids that error being displayed.