### PR TITLE
Skip account lookup on self-signed revoke, fixes #934

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -779,7 +779,7 @@ init_system() {
         echo '{"url":"'"${ACCOUNT_URL}"'"}' > "${ACCOUNT_ID_JSON}" # store the URL for next time
       fi
     fi
-  else
+  elif [[ "${COMMAND}" != "revoke" ]]; then
     echo "Fetching missing account information from CA..."
     if [[ ${API} -eq 1 ]]; then
       _exiterr "This is not implemented for ACMEv1! Consider switching to ACMEv2 :)"


### PR DESCRIPTION
This will fix #934
Due to the lack of documentation or tests I can not guarantee that it does not break other operations where a different account key should be used. 