### PR TITLE
Update dehydrated repo urls in man page

### DIFF
--- a/docs/man/dehydrated.1
+++ b/docs/man/dehydrated.1
@@ -26,7 +26,7 @@ single certificate valid for both "example.net" and "example.com" through the \f
 Alternative Name\fR (SAN) field.
 
 For the next step, one way of verifying domain name ownership needs to be
-configured.  Dehydrated implements \fIhttp-01\fR and \fIdns-01\fR verification. 
+configured.  Dehydrated implements \fIhttp-01\fR and \fIdns-01\fR verification.
 
 The \fIhttp-01\fR verification provides proof of ownership by providing a
 challenge token. In order to do that, the directory referenced in the
@@ -139,7 +139,7 @@ secp384r1
 The program exits 0 if everything was fine, 1 if an error occurred.
 .SH BUGS
 Please report any bugs that you may encounter at the project web site
-.UR https://github.com/lukas2511/dehydrated/issues
+.UR https://github.com/dehydrated-io/dehydrated/issues
 .UE .
 .SH AUTHOR
 Dehydrated was written by Lukas Schauer. This man page was contributed by
@@ -151,5 +151,5 @@ distribution for licensing information.
 .SH SEE ALSO
 Full documentation along with configuration examples are provided in the \fIdocs\fR
 directory of the distribution, or at
-.UR https://github.com/lukas2511/dehydrated/tree/master/docs
+.UR https://github.com/dehydrated-io/dehydrated/tree/master/docs
 .UE .


### PR DESCRIPTION
The dehydrated repo urls are not up2date in the man page of dehydrated.