### PR TITLE
dehydrated#910 hexdump not always available

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -260,7 +260,7 @@ _mktemp() {
 # Check for script dependencies
 check_dependencies() {
   # look for required binaries
-  for binary in grep mktemp diff sed awk curl cut head tail hexdump; do
+  for binary in grep mktemp diff sed awk curl cut head tail od; do
     bin_path="$(command -v "${binary}" 2>/dev/null)" || _exiterr "This script requires ${binary}."
     [[ -x "${bin_path}" ]] || _exiterr "${binary} found in PATH but it's not executable"
   done
@@ -839,7 +839,7 @@ hex2bin() {
 
 # Convert binary data to hex string
 bin2hex() {
-  hexdump -v -e '/1 "%02x"'
+  od -t xC -An | tr -d '[:space:]'
 }
 
 # OpenSSL writes to stderr/stdout even when there are no errors. So just


### PR DESCRIPTION
Fixes #910 by switching from `hexdump` which may not be available on Debian, Ubuntu, or some Unix systems to `od`, which is is part of coreutils on Linux and is part of the base operating system on Unix (macOS, *BSD, illumos) systems.