### PR TITLE
check for existence of ocsp responder if OCSP_FETCH="yes" is set

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1945,7 +1945,7 @@ command_sign_domains() {
         update_ocsp="yes"
       fi
 
-      if [[ "${update_ocsp}" = "yes" ]]; then
+      if [[ "${update_ocsp}" = "yes" && -n $("${OPENSSL}" x509 -in "${cert}" -noout -ocsp_uri) ]]; then
         echo " + Updating OCSP stapling file"
         ocsp_timestamp="$(date +%s)"
         if grep -qE "^(openssl (0|(1\.0))\.)|(libressl (1|2|3)\.)" <<< "$(${OPENSSL} version | awk '{print tolower($0)}')"; then


### PR DESCRIPTION
this allows having globally OCSP_FETCH="yes" and not failing for certificates that don't have any ocsp support at all (like latest letsencrypt certs...)