### PR TITLE
fix misleading doc

### DIFF
--- a/docs/domains_txt.md
+++ b/docs/domains_txt.md
@@ -52,10 +52,10 @@ the value
 KEY_ALGO="rsa"
 ```
 
-or respectively
+or respectively specifying curve name for ECDSA
 
 ```
-KEY_ALGO="ecdsa"
+KEY_ALGO="secp384r1"
 ```
 
 ### Wildcards


### PR DESCRIPTION
https://github.com/dehydrated-io/dehydrated/blob/cf9e6a33fd3ed0576e2f0d14f20c4a96909c1fee/docs/domains_txt.md#L48-L59

The documentation mentioned `KEY_ALGO="ecdsa"` for Per Certificate Config. It seems that this value `"ecdsa"` is not supported and user should specify ECDSA curve name instead.